### PR TITLE
Update package dependencies: bump vite to 6.2.6, caniuse-lite to 1.0.…

### DIFF
--- a/library/src/components/sidenavigation/SideNavigation.tsx
+++ b/library/src/components/sidenavigation/SideNavigation.tsx
@@ -582,6 +582,8 @@ function NestableNavigationContent({
 	goBackButtonIconStyle,
 	goBackButtonTitleClassName,
 	goBackButtonTitleStyle,
+	contentClassName,
+	contentStyle,
 	children,
 	sideNavStoreIdent = "default",
 	className,
@@ -697,7 +699,11 @@ function NestableNavigationContent({
 							ease: "easeInOut",
 							//delay: animTime * 0.5,
 						}}
-						className="border-border-separator box-border flex size-full border-b-2 border-t-2 border-solid border-x-0"
+						className={twMerge(
+							"border-border-separator box-border flex size-full border-b-2 border-t-2 border-solid border-x-0",
+							contentClassName,
+						)}
+						style={contentStyle}
 						onAnimationStart={() => {
 							onAnimationStart?.()
 						}}

--- a/library/src/components/sidenavigation/SideNavigation.tsx
+++ b/library/src/components/sidenavigation/SideNavigation.tsx
@@ -541,6 +541,8 @@ type _NestableNavigationContentProps = {
 	goBackButtonIconStyle?: React.CSSProperties
 	goBackButtonTitleClassName?: string
 	goBackButtonTitleStyle?: React.CSSProperties
+	contentClassName?: string
+	contentStyle?: React.CSSProperties
 	children: React.ReactNode
 	className?: string
 	style?: React.CSSProperties

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
 				"tailwindcss": "^4.0.3",
 				"typescript": "^5.8.3",
 				"typescript-plugin-css-modules": "^5.1.0",
-				"vite": "^6.2.5",
+				"vite": "^6.2.6",
 				"vite-plugin-dts": "^4.5.3",
 				"vitest": "^3.1.1"
 			},
@@ -5630,9 +5630,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001712",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
-			"integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
+			"version": "1.0.30001713",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -6202,9 +6202,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.134",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.134.tgz",
-			"integrity": "sha512-zSwzrLg3jNP3bwsLqWHmS5z2nIOQ5ngMnfMZOWWtXnqqQkPVyOipxK98w+1beLw1TB+EImPNcG8wVP/cLVs2Og==",
+			"version": "1.5.135",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.135.tgz",
+			"integrity": "sha512-8gXUdEmvb+WCaYUhA0Svr08uSeRjM2w3x5uHOc1QbaEVzJXB8rgm5eptieXzyKoVEtinLvW6MtTcurA65PeS1Q==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -7361,9 +7361,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.8.1.tgz",
-			"integrity": "sha512-GrO2l93P8xCWBSTBX9l2BxI78VU/MAAYag+pG8curS3aBGy0++ZlxrQ7PdUOUVMbn5BwkGb6+eRrnf43ipnFEA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.8.2.tgz",
+			"integrity": "sha512-5nZbBNP44sFCDjSoB//0N7m508APCgbQ4mGGo1KJGBYyCKNHfry1Pvd0JVHZIxjdnqn8nFRBAN/eFB6Rk/4w5w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11878,9 +11878,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-			"integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"tailwindcss": "^4.0.3",
 		"typescript": "^5.8.3",
 		"typescript-plugin-css-modules": "^5.1.0",
-		"vite": "^6.2.5",
+		"vite": "^6.2.6",
 		"vite-plugin-dts": "^4.5.3",
 		"vitest": "^3.1.1"
 	},


### PR DESCRIPTION
…30001713, electron-to-chromium to 1.5.135, and hookified to 1.8.2. Enhance SideNavigation component with additional contentClassName and contentStyle props for improved customization.